### PR TITLE
Test naming

### DIFF
--- a/test/client_agent/CMakeLists.txt
+++ b/test/client_agent/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2017-present Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set(_test_name itest-client-agent)
+
 cmake_host_system_information(RESULT HOSTNAME_SUFFIX QUERY HOSTNAME)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DEFAULT_FASTRTPS_PROFILES.xml.in
@@ -19,9 +21,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DEFAULT_FASTRTPS_PROFILES.xml.in
     @ONLY
     )
 
-add_executable(client-agent-test ClientAgentInteraction.cpp)
+add_executable(${_test_name} ClientAgentInteraction.cpp)
 
-add_gtest(client-agent-test
+add_gtest(${_test_name}
     SOURCES
         ClientAgentInteraction.cpp
     ENVIRONMENTS
@@ -29,12 +31,12 @@ add_gtest(client-agent-test
         $<$<PLATFORM_ID:Windows>:PATH=${CMAKE_PREFIX_PATH}/bin>
     )
 
-target_include_directories(client-agent-test
+target_include_directories(${_test_name}
     PRIVATE
         ${GTEST_INCLUDE_DIR}
     )
 
-target_link_libraries(client-agent-test
+target_link_libraries(${_test_name}
     PRIVATE
         interaction_client
         microxrcedds_agent
@@ -42,7 +44,7 @@ target_link_libraries(client-agent-test
         ${CMAKE_THREAD_LIBS_INIT}
     )
 
-set_target_properties(client-agent-test PROPERTIES
+set_target_properties(${_test_name} PROPERTIES
     CXX_STANDARD
         11
     CXX_STANDARD_REQUIRED

--- a/test/cross_serialization/CMakeLists.txt
+++ b/test/cross_serialization/CMakeLists.txt
@@ -1,6 +1,4 @@
-###############################################################################
-#
-# Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2017-present Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,28 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-###############################################################################
+
+set(_test_name itest-xserialization)
 
 set(SRCS
     CrossSerialization.cpp
     AgentSerialization.cpp
     ClientSerialization.cpp
     )
-add_executable(cross_serialization_test ${SRCS})
-add_gtest(cross_serialization_test
+
+add_executable(${_test_name} ${SRCS})
+
+add_gtest(${_test_name}
     SOURCES
         ${SRCS}
     ENVIRONMENTS
         $<$<PLATFORM_ID:Linux>:LD_LIBRARY_PATH=${CMAKE_PREFIX_PATH}/lib>
     )
 
-target_include_directories(cross_serialization_test
+target_include_directories(${_test_name}
     PRIVATE
         ${UCLIENT_SOURCE_DIR}/src/c
     )
 
-target_link_libraries(cross_serialization_test
+target_link_libraries(${_test_name}
     PRIVATE
         microxrcedds_client
         microxrcedds_agent
@@ -44,7 +44,7 @@ target_link_libraries(cross_serialization_test
         ${CMAKE_THREAD_LIBS_INIT}
     )
 
-set_target_properties(cross_serialization_test PROPERTIES
+set_target_properties(${_test_name} PROPERTIES
     CXX_STANDARD
         11
     CXX_STANDARD_REQUIRED

--- a/test/discovery/CMakeLists.txt
+++ b/test/discovery/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2017-present Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set(_test_name itest-discovery)
+
 cmake_host_system_information(RESULT HOSTNAME_SUFFIX QUERY HOSTNAME)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DEFAULT_FASTRTPS_PROFILES.xml.in
@@ -19,9 +21,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DEFAULT_FASTRTPS_PROFILES.xml.in
     @ONLY
     )
 
-add_executable(discovery-test DiscoveryIntegration.cpp)
+add_executable(${_test_name} DiscoveryIntegration.cpp)
 
-add_gtest(discovery-test
+add_gtest(${_test_name}
     SOURCES
         DiscoveryIntegration.cpp
     ENVIRONMENTS
@@ -29,12 +31,12 @@ add_gtest(discovery-test
         $<$<PLATFORM_ID:Windows>:PATH=${CMAKE_PREFIX_PATH}/bin>
     )
 
-target_include_directories(discovery-test
+target_include_directories(${_test_name}
     PRIVATE
         ${GTEST_INCLUDE_DIR}
     )
 
-target_link_libraries(discovery-test
+target_link_libraries(${_test_name}
     PRIVATE
         interaction_client
         microxrcedds_agent
@@ -42,7 +44,7 @@ target_link_libraries(discovery-test
         ${CMAKE_THREAD_LIBS_INIT}
     )
 
-set_target_properties(discovery-test PROPERTIES
+set_target_properties(${_test_name} PROPERTIES
     CXX_STANDARD
         11
     CXX_STANDARD_REQUIRED

--- a/test/publisher_subscriber/CMakeLists.txt
+++ b/test/publisher_subscriber/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2017-present Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set(_test_name itest-pubsub)
+
 cmake_host_system_information(RESULT HOSTNAME_SUFFIX QUERY HOSTNAME)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DEFAULT_FASTRTPS_PROFILES.xml.in
@@ -19,9 +21,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/DEFAULT_FASTRTPS_PROFILES.xml.in
     @ONLY
     )
 
-add_executable(publisher-subscriber-interaction-test PublisherSubscriberInteraction.cpp)
+add_executable(${_test_name} PublisherSubscriberInteraction.cpp)
 
-add_gtest(publisher-subscriber-interaction-test
+add_gtest(${_test_name}
     SOURCES
         PublisherSubscriberInteraction.cpp
     ENVIRONMENTS
@@ -29,12 +31,12 @@ add_gtest(publisher-subscriber-interaction-test
         $<$<PLATFORM_ID:Windows>:PATH=${CMAKE_PREFIX_PATH}/bin>
     )
 
-target_include_directories(publisher-subscriber-interaction-test
+target_include_directories(${_test_name}
     PRIVATE
         ${GTEST_INCLUDE_DIR}
     )
 
-target_link_libraries(publisher-subscriber-interaction-test
+target_link_libraries(${_test_name}
     PRIVATE
         interaction_client
         microxrcedds_agent
@@ -42,7 +44,7 @@ target_link_libraries(publisher-subscriber-interaction-test
         ${CMAKE_THREAD_LIBS_INIT}
     )
 
-set_target_properties(publisher-subscriber-interaction-test PROPERTIES
+set_target_properties(${_test_name} PROPERTIES
         CXX_STANDARD
             11
         CXX_STANDARD_REQUIRED

--- a/test/shapes_demo/CMakeLists.txt
+++ b/test/shapes_demo/CMakeLists.txt
@@ -1,6 +1,4 @@
-###############################################################################
-#
-# Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+# Copyright 2017-present Proyectos y Sistemas de Mantenimiento SL (eProsima).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-###############################################################################
+
+set(_test_name itest-shapesdemo)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(PLATFORM_NAME_LINUX ON)
@@ -24,7 +22,7 @@ endif()
 
 set(SRCS ShapesDemo.cpp)
 
-add_executable(shapes_demo_test ${SRCS})
+add_executable(${_test_name} ${SRCS})
 add_gtest(shapes_demo_test
     SOURCES
         ${SRCS}
@@ -33,26 +31,26 @@ add_gtest(shapes_demo_test
         $<$<PLATFORM_ID:Windows>:PATH=${CMAKE_PREFIX_PATH}/bin>
     )
 
-target_include_directories(shapes_demo_test
+target_include_directories(${_test_name}
     PRIVATE
         ${PROJECT_BINARY_DIR}/include
         ${GTEST_INCLUDE_DIRS}
     )
 
-target_link_libraries(shapes_demo_test
+target_link_libraries(${_test_name}
     PRIVATE
         microxrcedds_agent
         ${GTEST_BOTH_LIBRARIES}
         ${CMAKE_THREAD_LIBS_INIT}
     )
 
-target_compile_definitions(shapes_demo_test
+target_compile_definitions(${_test_name}
     PRIVATE
         $<$<BOOL:${PLATFORM_NAME_LINUX}>:PLATFORM_NAME_LINUX>
         $<$<BOOL:${PLATFORM_NAME_WINDOWS}>:PLATFORM_NAME_WINDOWS>
     )
 
-set_target_properties(shapes_demo_test PROPERTIES
+set_target_properties(${_test_name} PROPERTIES
     CXX_STANDARD
         11
     CXX_STANDARD_REQUIRED


### PR DESCRIPTION
This pull request changes the test naming to avoid CI due to Windows `MAX_PATH`.